### PR TITLE
Fixed description for mushrooms under Other Vegetables for metric

### DIFF
--- a/DailyDozen/DailyDozen/App/Texts/Details.plist
+++ b/DailyDozen/DailyDozen/App/Texts/Details.plist
@@ -442,7 +442,7 @@
 				<string>60 g raw leafy vegetables</string>
 				<string>50 g raw or cooked nonleafy vegetables</string>
 				<string>125 ml vegetable juice</string>
-				<string>7 g</string>
+				<string>7 g dried mushrooms</string>
 			</array>
 			<key>Imperial</key>
 			<array>


### PR DESCRIPTION
I noticed something said `7g` but nothing more. Switching to imperial, I saw that it should have been a reference for `dried mushrooms`. 

I saw the same was reflected in the data from the repo so I figured I would send an update for it.