### PR TITLE
Three servings exercise

### DIFF
--- a/DailyDozen/DailyDozen/App/Realm/RealmConfig.swift
+++ b/DailyDozen/DailyDozen/App/Realm/RealmConfig.swift
@@ -46,7 +46,7 @@ enum RealmConfig {
             Item(name: "Spices", states: [false]),
             Item(name: "Whole Grains", states: [false, false, false]),
             Item(name: "Beverages", states: [false, false, false, false, false]),
-            Item(name: "Exercise", states: [false]),
+            Item(name: "Exercise", states: [false, false, false]),
             Item(name: "Vitamin B12", states: [false]),
             Item(name: "Vitamin D", states: [false])
         ]

--- a/DailyDozen/DailyDozen/App/Texts/Details.plist
+++ b/DailyDozen/DailyDozen/App/Texts/Details.plist
@@ -939,13 +939,13 @@
 		<dict>
 			<key>Metric</key>
 			<array>
-				<string>90 minutes of moderate-intensity activity</string>
-				<string>40 minutes of vigorous-intensity activity</string>
+				<string>30 minutes of moderate-intensity activity</string>
+				<string>15 minutes of vigorous-intensity activity</string>
 			</array>
 			<key>Imperial</key>
 			<array>
-				<string>90 minutes of moderate-intensity activity</string>
-				<string>40 minutes of vigorous-intensity activity</string>
+				<string>30 minutes of moderate-intensity activity</string>
+				<string>15 minutes of vigorous-intensity activity</string>
 			</array>
 		</dict>
 		<key>Types</key>


### PR DESCRIPTION
40 minutes vigorous was 13.34 min when divided by 3. I bumped this to 15 instead so the total would end up being 45 but the number 15 seemed to make more sense. 

I would need to test to make sure this doesn't do anything weird with the legacy daily data but it looks like it is abstracted away enough where it wouldn't.