### PR TITLE
[Accessibility] Conform Doze Back Button height to apple guideline

### DIFF
--- a/DailyDozen/DailyDozen/DozeSection/DozeEntry/Views/DozeEntryPagerLayout.storyboard
+++ b/DailyDozen/DailyDozen/DozeSection/DozeEntry/Views/DozeEntryPagerLayout.storyboard
@@ -62,10 +62,10 @@
                                         </connections>
                                     </view>
                                     <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aJT-dy-You" customClass="RoundedView" customModule="DailyDozen" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="738" width="414" height="30"/>
+                                        <rect key="frame" x="0.0" y="724" width="414" height="44"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Qfe-bW-SP4">
-                                                <rect key="frame" x="153.5" y="-1" width="107" height="32"/>
+                                                <rect key="frame" x="12" y="6" width="390" height="32"/>
                                                 <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="17"/>
                                                 <state key="normal" title="Back to today">
                                                     <color key="titleColor" red="0.99989169840000003" green="1" blue="0.99988096950000005" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -76,8 +76,10 @@
                                             </button>
                                         </subviews>
                                         <constraints>
-                                            <constraint firstAttribute="height" constant="30" id="R3o-nK-p0U"/>
+                                            <constraint firstItem="Qfe-bW-SP4" firstAttribute="leading" secondItem="aJT-dy-You" secondAttribute="leading" constant="12" id="OeM-Hu-Rcb"/>
+                                            <constraint firstAttribute="height" constant="44" id="R3o-nK-p0U"/>
                                             <constraint firstItem="Qfe-bW-SP4" firstAttribute="centerX" secondItem="aJT-dy-You" secondAttribute="centerX" id="SwU-DD-GIQ"/>
+                                            <constraint firstAttribute="trailing" secondItem="Qfe-bW-SP4" secondAttribute="trailing" constant="12" id="glC-Mh-Vf8"/>
                                             <constraint firstItem="Qfe-bW-SP4" firstAttribute="centerY" secondItem="aJT-dy-You" secondAttribute="centerY" id="vFh-IS-fpv"/>
                                         </constraints>
                                         <userDefinedRuntimeAttributes>


### PR DESCRIPTION
Hello @marc-medley,

My name is Jamie and I'm an user of Daily Dozen and iOS Developper that's passionate about Accessibility.

Here are a few storyboard line changes – I noticed the `DozeBackButton`'s width was truncated within it's parent view and it's height was a few points short of the 44pt minimum recommended by the Apple Guidelines.
>  [Apple Developer, *Human Interface Guidelines*](https://developer.apple.com/design/human-interface-guidelines/ios/visual-design/adaptivity-and-layout/) : **Visual Design**, *Adaptivity and Layout*

I work on a public service app in my day job, and have a few ideas for the Voice Over user journey and more. I'd would love to contribute over the summer more if the project team is at all interested. 🙌 

Cheers 🚀 
