### PR TITLE
Accept local decimal separator for the weight field.

### DIFF
--- a/DailyDozen/DailyDozen/WeightSection/WeightEntry/Controllers/WeightEntryViewController.swift
+++ b/DailyDozen/DailyDozen/WeightSection/WeightEntry/Controllers/WeightEntryViewController.swift
@@ -74,19 +74,24 @@ class WeightEntryViewController: UIViewController {
     func saveIBWeight(ampm: DataWeightType) {
         let datestampKey = currentViewDateWeightEntry.datestampKey
         LogService.shared.debug("•HK• WeightEntryViewController saveIBWeight \(datestampKey)")
-        
+
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.maximumFractionDigits = 2
+
         if
             let timeText = ampm == .am ? timeAMInput.text : timePMInput.text,
             let weightText = ampm == .am ? weightAM.text : weightPM.text,
             let date = Date(healthkit: "\(datestampKey) \(timeText)"),
-            var weight = Double(weightText),
-            weight > 5.0 {
-            
-            // Update local data
-            if SettingsManager.isImperial() {
-                weight = weight / 2.2046 // kg = lbs * 2.2046
+            let weightNSNumber = formatter.number(from: weightText) {
+            var weight = Double(truncating: weightNSNumber)
+            if weight > 5.0 {
+                // Update local data
+                if SettingsManager.isImperial() {
+                    weight = weight / 2.2046 // kg = lbs * 2.2046
+                }
+                HealthSynchronizer.shared.syncWeightPut(date: date, ampm: ampm, kg: weight)
             }
-            HealthSynchronizer.shared.syncWeightPut(date: date, ampm: ampm, kg: weight)
         }
         // Update local counter
         updateWeightDataCount()


### PR DESCRIPTION
I've spotted an issue while inserting weight for users that have `,` as the decimal separator. They can't insert a decimal number using the on-screen numeric keyboard as it does not have a key with the period `.` symbol and using a `,` is an invalid input. One can work around this issue by typing their weight in another app and pasting it into the weight field. I believe this is really disruptive experience for users and wanted to fix it.

To fix that issue I've used a number formatter to convert the weight string into a double.

Screenshot of the numeric keyboard with the `,` separator:
<img width="300" src="https://user-images.githubusercontent.com/26921994/127752543-4d31dc63-60cb-4b9f-86b0-1f5322c6a9a1.jpeg">
