### PR TITLE
Fix unloaded pdf tab icon with open system sf symbol

### DIFF
--- a/DailyDozen/DailyDozen/App/Controllers/MainViewController.swift
+++ b/DailyDozen/DailyDozen/App/Controllers/MainViewController.swift
@@ -156,7 +156,7 @@ class MainViewController: UIViewController {
         tabDailyDozenViewController.title = titleDoze
         let tabDozeItem = UITabBarItem(
             title: titleDoze, // shows below tab bar item icon
-            image: UIImage(named: "ic_tabapp_dailydozen"),
+            image: UIImage(systemName: "12.square.fill"),
             tag: 0
         )
         tabDozeItem.accessibilityIdentifier = "navtab_doze_access"


### PR DESCRIPTION
In reading the code, I saw that the asset `ic_tabnav_Daily12_square.pdf` is supposed to be the image loaded in with the `UIImage(named:)`

<img width="336" alt="Screenshot 2024-01-08 at 6 47 47 PM" src="https://github.com/nutritionfactsorg/daily-dozen-ios/assets/38720242/ae6733fa-d125-43f6-87f7-b21f3fb83c66">

<img width="1236" alt="Screenshot 2024-01-08 at 6 42 16 PM" src="https://github.com/nutritionfactsorg/daily-dozen-ios/assets/38720242/f70e5f75-3709-428c-8788-f6a7cc439b3f">**

However we see in other screens in other issues like #72 that the rendering is just a black square ◼️

To fix this regression I propose swamping out the `pdf` for an SF Symbol that's available for free use and has very nearly the same appearance:

<img width="336" alt="Simulator Screenshot - iPhone 15 - 2024-01-08 at 18 41 30" src="https://github.com/nutritionfactsorg/daily-dozen-ios/assets/38720242/7e340af0-5c70-450a-be16-68b7a1d19193">

<img width="336" alt="Simulator Screenshot - iPhone 15 - 2024-01-08 at 18 41 36" src="https://github.com/nutritionfactsorg/daily-dozen-ios/assets/38720242/db4e8c9b-a1a3-4f5b-88ea-04202c5148d8">

There are alternatives too, see search for "12" with official SF Symbols desktop App :
<img width="1083" alt="Screenshot 2024-01-08 at 7 02 18 PM" src="https://github.com/nutritionfactsorg/daily-dozen-ios/assets/38720242/6d3d4e96-1f40-4061-bded-99ccea08af49">

Otherwise I believe there's vector issues with the PDF that I'd be happy to help with cooperation from the design team 🙏 
