### PR TITLE
docs: add local getting-started setup guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,14 @@ If an Issue Ticket proceeds to a "go" plan, then you will be pointed to which br
 
 We want to foster a community of participation and learning, especially for people interested in committing to Open Source Software (OSS) projects. Kent C. Dodds provides a great set of tutorials covering [How to Contribute to an Open Source Project on GitHub][contribute-os] geared toward submitting your first Pull Request.
 
+**Local Development Quick Start**
+
+1. Install the latest stable [Xcode](https://apps.apple.com/us/app/xcode/id497799835) on macOS.
+2. Clone this repository and open `DailyDozen/DailyDozen.xcodeproj` in Xcode.
+3. Select the `DailyDozen` scheme and an iPhone Simulator.
+4. Run the app with `Product > Run` (`Cmd+R`).
+5. If package dependencies fail to resolve, run `File > Packages > Resolve Package Versions` in Xcode.
+
 Developer documentation for the DailyDozen iOS application is in located in the `Docs` directory.  The [Docs/DeveloperNotes.md](Docs/DeveloperNotes.md) file provides dev environment, build, and debug information particular to the DailyDozen iOS app development.
 
 **Before you submit your Pull Request consider the following guidelines:**

--- a/README.md
+++ b/README.md
@@ -8,6 +8,21 @@ In the years of research required to create the more than a thousand evidence-ba
 
 Dr. Greger’s Daily Dozen details the healthiest foods and how many servings of each we should try to check off every day. He explains his rationale in his book [How Not to Die][book]. All his proceeds from his books, DVDs, and speaking engagements is all donated to charity.
 
+## Getting Started (Development)
+
+1. Install the latest stable [Xcode](https://apps.apple.com/us/app/xcode/id497799835) on macOS.
+2. Clone this repository and open the project:
+   ```bash
+   git clone https://github.com/nutritionfactsorg/daily-dozen-ios.git
+   cd daily-dozen-ios
+   open DailyDozen/DailyDozen.xcodeproj
+   ```
+3. In Xcode, select the `DailyDozen` scheme and an iPhone Simulator target.
+4. Build and run with `Product > Run` (or `Cmd+R`).
+5. If dependencies are not resolved automatically, run `File > Packages > Resolve Package Versions` in Xcode.
+
+For additional build and debug details, see [Docs/DeveloperNotes.md](Docs/DeveloperNotes.md).
+
 ## Daily Dozen on the App Store
 
 <a href="https://apps.apple.com/us/app/dr-gregers-daily-dozen/id1060700802" alt="Download from the App Store" target="%5fblank"><img src="README_files/app-store.png" width="200"></a>


### PR DESCRIPTION
## Summary
This PR adds a practical local setup section to both `README.md` and `CONTRIBUTING.md` so new contributors can quickly prepare and run the app.

### Added
- `README.md`: new **Getting Started (Development)** section with clone/open/run steps
- `CONTRIBUTING.md`: new **Local Development Quick Start** section with the same core setup steps
- links to `Docs/DeveloperNotes.md` for deeper build/debug details

Fixes #74.
